### PR TITLE
Fail checkEnv when required vars missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ramking_AI_new
 ランキングや順位づけをするAI
+
+## Environment variables
+
+Run `npm test` to verify that the required environment variables are set. The
+command relies on the exit code of the check script and exits with code `1` if
+any required key is missing.

--- a/scripts/checkEnv.js
+++ b/scripts/checkEnv.js
@@ -1,8 +1,15 @@
 const required = ["OPENAI_API_KEY", "SEARCH_API_KEY"];
+let missing = false;
+
 required.forEach((key) => {
   if (process.env[key]) {
     console.log(`${key} is set`);
   } else {
     console.warn(`${key} is not set`);
+    missing = true;
   }
 });
+
+if (missing) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- exit with a failure code if required env vars are unset
- document env var check via npm test

## Testing
- `OPENAI_API_KEY=foo SEARCH_API_KEY=bar npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a12b461cb483238f2e33d891358838