### PR TITLE
feat: add scoring logic and evaluation orchestration

### DIFF
--- a/src/evaluate-with-search.ts
+++ b/src/evaluate-with-search.ts
@@ -1,55 +1,143 @@
+import { calculateFinalScore, ScoringCriteria, ItemFactors } from './scoring';
+
 export interface EvaluateRequest {
   projectId: string;
   refresh?: boolean;
+  model?: 'openai' | 'gemini';
 }
 
-export async function evaluateWithSearch({ projectId, refresh = true }: EvaluateRequest) {
+interface Item {
+  id: string;
+  title: string;
+  metrics: Record<string, number>;
+  ageDays: number;
+  sourceCred: number;
+  crossRefs: number;
+}
+
+interface Project {
+  items: Item[];
+  criteria: ScoringCriteria;
+}
+
+interface Evaluation {
+  itemId: string;
+  finalScore: number;
+  reasons: { top: string[]; cons: string[] };
+}
+
+async function fetchProject(projectId: string): Promise<Project> {
+  // In a real implementation this would query the database. For demo purposes
+  // we return a tiny static project.
+  return {
+    items: [
+      {
+        id: '1',
+        title: 'Sample Item A',
+        metrics: { price: 0.8, quality: 0.9 },
+        ageDays: 1,
+        sourceCred: 0.8,
+        crossRefs: 0.5
+      },
+      {
+        id: '2',
+        title: 'Sample Item B',
+        metrics: { price: 0.6, quality: 0.7 },
+        ageDays: 5,
+        sourceCred: 0.6,
+        crossRefs: 0.3
+      }
+    ],
+    criteria: {
+      weights: { price: 0.5, quality: 0.5 },
+      lambda: 0.01,
+      alpha: 0.7,
+      beta: 0.3
+    }
+  };
+}
+
+async function searchAndUpdate(item: Item, apiKey: string): Promise<void> {
+  const resp = await fetch(`https://api.example.com/search?q=${encodeURIComponent(item.title)}`, {
+    headers: { 'X-API-Key': apiKey }
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Search API error: ${resp.status} ${body}`);
+  }
+  const data: any[] = await resp.json();
+  if (Array.isArray(data) && data.length > 0) {
+    const first = data[0];
+    if (typeof first.ageDays === 'number') item.ageDays = first.ageDays;
+    if (typeof first.sourceCred === 'number') item.sourceCred = first.sourceCred;
+    item.crossRefs = data.length;
+  }
+}
+
+async function generateReasons(model: 'openai' | 'gemini', apiKey: string, item: Item): Promise<{ top: string[]; cons: string[] }> {
+  const prompt = `Provide top reasons and cons for ${item.title} given metrics ${JSON.stringify(item.metrics)}. Respond in JSON {\"top\":[],\"cons\":[]}`;
+  const url = model === 'gemini'
+    ? 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent'
+    : 'https://api.openai.com/v1/responses';
+  const body = model === 'gemini'
+    ? { contents: [{ parts: [{ text: prompt }]}] }
+    : { model: 'gpt-4.1-mini', input: prompt };
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(body)
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`LLM API error: ${resp.status} ${text}`);
+  }
+  const json = await resp.json();
+  try {
+    const text = model === 'gemini'
+      ? json?.candidates?.[0]?.content?.parts?.[0]?.text ?? '{}'
+      : json.output_text ?? json.choices?.[0]?.message?.content ?? '{}';
+    return JSON.parse(text);
+  } catch {
+    return { top: [], cons: [] };
+  }
+}
+
+export async function evaluateWithSearch({ projectId, refresh = true, model = 'openai' }: EvaluateRequest): Promise<{ evaluations: Evaluation[]; updatedAt: string }> {
+  const project = await fetchProject(projectId);
   const searchApiKey = process.env.SEARCH_API_KEY;
   const openaiApiKey = process.env.OPENAI_API_KEY;
+  const geminiApiKey = process.env.GEMINI_API_KEY;
+  const modelApiKey = model === 'openai' ? openaiApiKey : geminiApiKey;
 
-  if (!openaiApiKey) {
-    throw new Error('Missing OPENAI_API_KEY');
+  if (!modelApiKey) {
+    throw new Error('Missing API key for selected model');
   }
   if (refresh && !searchApiKey) {
     throw new Error('Missing SEARCH_API_KEY');
   }
 
-  let searchResults: unknown[] = [];
-  if (refresh) {
-    try {
-      const searchResp = await fetch(
-        `https://api.example.com/search?q=${encodeURIComponent(projectId)}`,
-        {
-          headers: { 'X-API-Key': searchApiKey! }
-        }
-      );
-
-      if (!searchResp.ok) {
-        const body = await searchResp.text();
-        throw new Error(`Search API error: ${searchResp.status} ${body}`);
-      }
-
-      searchResults = await searchResp.json();
-    } catch (err) {
-      console.error('Search API request failed', err);
-      throw err;
+  for (const item of project.items) {
+    if (refresh) {
+      await searchAndUpdate(item, searchApiKey!);
     }
   }
 
-  const aiResp = await fetch('https://api.openai.com/v1/responses', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${openaiApiKey}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      model: 'gpt-4.1-mini',
-      input: `Score project ${projectId} with data ${JSON.stringify(searchResults)}`
-    })
-  });
-
-  if (!aiResp.ok) {
-    throw new Error(`OpenAI API error: ${aiResp.status}`);
+  const evaluations: Evaluation[] = [];
+  for (const item of project.items) {
+    const factors: ItemFactors = {
+      metrics: item.metrics,
+      ageDays: item.ageDays,
+      sourceCred: item.sourceCred,
+      crossRefs: item.crossRefs,
+      penalties: 0
+    };
+    const finalScore = calculateFinalScore(factors, project.criteria);
+    const reasons = await generateReasons(model, modelApiKey, item);
+    evaluations.push({ itemId: item.id, finalScore, reasons });
   }
-  return aiResp.json();
+
+  return { evaluations, updatedAt: new Date().toISOString() };
 }

--- a/src/scoring.ts
+++ b/src/scoring.ts
@@ -1,0 +1,38 @@
+export interface ScoringCriteria {
+  weights: Record<string, number>;
+  /** freshness decay factor */
+  lambda: number;
+  /** credibility weight */
+  alpha: number;
+  /** cross reference weight */
+  beta: number;
+}
+
+export interface ItemFactors {
+  metrics: Record<string, number>;
+  /** age of the latest information in days */
+  ageDays: number;
+  /** credibility of the source 0-1 */
+  sourceCred: number;
+  /** cross reference score 0-1 */
+  crossRefs: number;
+  /** accumulated penalties */
+  penalties: number;
+}
+
+export function calculateBaseScore(metrics: Record<string, number>, weights: Record<string, number>): number {
+  let score = 0;
+  for (const key of Object.keys(weights)) {
+    const w = weights[key] ?? 0;
+    const x = metrics[key] ?? 0;
+    score += w * x;
+  }
+  return score;
+}
+
+export function calculateFinalScore(item: ItemFactors, criteria: ScoringCriteria): number {
+  const base = calculateBaseScore(item.metrics, criteria.weights);
+  const freshness = Math.exp(-criteria.lambda * item.ageDays);
+  const trust = Math.min(1, criteria.alpha * item.sourceCred + criteria.beta * item.crossRefs);
+  return base * freshness * trust - item.penalties;
+}


### PR DESCRIPTION
## Summary
- add scoring utilities for base/final score calculations
- orchestrate search, scoring and reasoning in evaluate-with-search

## Testing
- `npm test` *(fails: OPENAI_API_KEY is not set; SEARCH_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a142e01b54832399f2b928abc02c82