### PR TITLE
Add landing page UI and Tailwind setup

### DIFF
--- a/app/api/evaluate-with-search/route.ts
+++ b/app/api/evaluate-with-search/route.ts
@@ -1,5 +1,19 @@
-import { NextResponse } from 'next/server';
+import { NextRequest } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const form = await req.formData();
+  const criteria = form.get("criteria")?.toString() ?? "{}";
+  const candidates = (form.get("candidates")?.toString() ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // TODO: ここで実際の評価ロジック/モデル呼び出しを行う
+  const scores = candidates.map((c, i) => ({ item: c, score: candidates.length - i }));
+
+  return Response.json({ ok: true, criteria: JSON.parse(criteria), result: scores }, { status: 200 });
+}
 
 export async function GET() {
-  return NextResponse.json({ status: 'ok' });
+  return Response.json({ ok: true, ts: Date.now() });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import "./globals.css";
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="ja">
       <body>{children}</body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,24 @@
-import React from 'react';
+export default function Home() {
+  return (
+    <main className="p-8 max-w-3xl mx-auto space-y-6">
+      <h1 className="text-3xl font-bold">Ranking AI</h1>
+      <p className="text-gray-600">
+        JSON の評価基準と候補リストからランキングを生成します。
+      </p>
 
-export default function Page() {
-  return <h1>Hello, world!</h1>;
+      <form action="/api/evaluate-with-search" method="post" className="space-y-3">
+        <label className="block">
+          <span className="font-medium">Criteria (JSON)</span>
+          <textarea name="criteria" required rows={6} className="w-full border p-2 rounded" />
+        </label>
+        <label className="block">
+          <span className="font-medium">Candidates (comma-separated)</span>
+          <input name="candidates" required className="w-full border p-2 rounded" />
+        </label>
+        <button type="submit" className="px-4 py-2 rounded bg-black text-white">
+          Rank now
+        </button>
+      </form>
+    </main>
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,12 @@
         "@types/node": "^20.12.7",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
+        "autoprefixer": "^10.4.19",
         "eslint": "8.57.0",
+        "postcss": "^8.4.38",
+        "tailwindcss": "^3.4.4",
+        "prisma": "^5.16.1",
+        "tsx": "^4.9.3",
         "typescript": "5.4.5"
       }
     }

--- a/package.json
+++ b/package.json
@@ -26,9 +26,12 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "autoprefixer": "^10.4.19",
     "eslint": "8.57.0",
-    "typescript": "5.4.5",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
     "prisma": "^5.16.1",
-    "tsx": "^4.9.3"
+    "tsx": "^4.9.3",
+    "typescript": "5.4.5"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- replace the landing page with a form that posts ranking criteria and candidates to the evaluate API
- scaffold the evaluate-with-search API endpoint to parse form data and return dummy scores
- add Tailwind CSS/PostCSS configuration and global styles so utility classes resolve

## Testing
- not run (npm registry access denied in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5308cce6c8323bfcd2b659312e2ff