### PR TITLE
feat: restore deterministic ranking flow

### DIFF
--- a/app/api/evaluate-with-search/route.ts
+++ b/app/api/evaluate-with-search/route.ts
@@ -1,17 +1,47 @@
-import { NextRequest } from "next/server";
+// Node ランタイム（DBやNodeモジュールを使える）
+export const runtime = 'nodejs';
 
-export async function POST(req: NextRequest) {
-  const form = await req.formData();
-  const criteria = form.get("criteria")?.toString() ?? "{}";
-  const candidates = (form.get("candidates")?.toString() ?? "")
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
+type Criteria = Record<string, number>;
 
-  // TODO: ここで実際の評価ロジック/モデル呼び出しを行う
-  const scores = candidates.map((c, i) => ({ item: c, score: candidates.length - i }));
+/**
+ * デモ用の決定的なスコア関数（外部API不要・依存追加なし）
+ *  - criteria のキーと candidate の文字列で簡易スコアを算出
+ *  - 以前の「ランキングが返る」挙動を即再現するための軽量版
+ */
+function scoreCandidate(c: string, criteria: Criteria) {
+  const base = [...c].reduce((a, ch) => a + ch.charCodeAt(0), 0);
+  const weight = Object.values(criteria).reduce((a, b) => a + Number(b || 0), 0) || 1;
+  return Math.round((base % 101) * weight); // 0..100 * weight
+}
 
-  return Response.json({ ok: true, criteria: JSON.parse(criteria), result: scores }, { status: 200 });
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(async () => {
+      const fd = await req.formData(); // フォーム送信に対応
+      return {
+        criteria: JSON.parse((fd.get('criteria')?.toString() ?? '{}')),
+        candidates: (fd.get('candidates')?.toString() ?? '').split(',').map(s => s.trim()).filter(Boolean),
+      };
+    });
+
+    const criteria: Criteria =
+      typeof body.criteria === 'string' ? JSON.parse(body.criteria || '{}') : (body.criteria || {});
+    const candidates: string[] =
+      Array.isArray(body.candidates) ? body.candidates : ((body.candidates || '').split(','));
+
+    const items = candidates.map(s => s.trim()).filter(Boolean);
+    if (!items.length) {
+      return Response.json({ ok:false, message: 'No candidates provided' }, { status: 400 });
+    }
+
+    const results = items
+      .map(item => ({ item, score: scoreCandidate(item, criteria), reason: 'heuristic score' }))
+      .sort((a, b) => b.score - a.score);
+
+    return Response.json({ ok: true, criteria, results }, { status: 200 });
+  } catch (e: any) {
+    return Response.json({ ok:false, error: e?.message ?? 'unknown error' }, { status: 500 });
+  }
 }
 
 export async function GET() {

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,7 @@
+export const runtime = 'edge';
+export async function GET() {
+  return new Response(JSON.stringify({ ok: true, ts: Date.now() }), {
+    headers: { 'content-type': 'application/json' },
+    status: 200
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,90 @@
+"use client";
+import { useState } from "react";
+
+type Result = { item: string; score: number; reason?: string };
+
 export default function Home() {
+  const [criteria, setCriteria] = useState('{\n  "clarity": 1,\n  "creativity": 1\n}');
+  const [candidates, setCandidates] = useState('A,B,C');
+  const [results, setResults] = useState<Result[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setResults([]);
+    try {
+      // API に JSON で投げる（フォームPOSTより確実）
+      const res = await fetch("/api/evaluate-with-search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          criteria: JSON.parse(criteria || "{}"),
+          candidates: candidates.split(",").map(s => s.trim()).filter(Boolean),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) throw new Error(data?.error || data?.message || `HTTP ${res.status}`);
+      setResults(data.results as Result[]);
+    } catch (err: any) {
+      setError(err?.message ?? "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <main className="p-8 max-w-3xl mx-auto space-y-6">
       <h1 className="text-3xl font-bold">Ranking AI</h1>
-      <p className="text-gray-600">
-        JSON の評価基準と候補リストからランキングを生成します。
-      </p>
+      <p className="text-gray-600">JSON の評価基準と候補リストからランキングを生成します。</p>
 
-      <form action="/api/evaluate-with-search" method="post" className="space-y-3">
+      <form onSubmit={handleSubmit} className="space-y-3">
         <label className="block">
           <span className="font-medium">Criteria (JSON)</span>
-          <textarea name="criteria" required rows={6} className="w-full border p-2 rounded" />
+          <textarea
+            value={criteria}
+            onChange={(e) => setCriteria(e.target.value)}
+            rows={8}
+            className="w-full border p-2 rounded"
+          />
         </label>
         <label className="block">
           <span className="font-medium">Candidates (comma-separated)</span>
-          <input name="candidates" required className="w-full border p-2 rounded" />
+          <input
+            value={candidates}
+            onChange={(e) => setCandidates(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
         </label>
-        <button type="submit" className="px-4 py-2 rounded bg-black text-white">
-          Rank now
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+        >
+          {loading ? "Ranking..." : "Rank now"}
         </button>
       </form>
+
+      {error && (
+        <div className="text-red-600">Error: {error}</div>
+      )}
+
+      {results.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold mt-6">Results</h2>
+          <ol className="list-decimal pl-6">
+            {results.map((r, i) => (
+              <li key={r.item} className="leading-7">
+                <span className="font-semibold">{i + 1}. {r.item}</span>
+                <span className="ml-2 text-sm text-gray-500">score: {r.score}</span>
+                {r.reason ? <span className="ml-2 text-sm text-gray-400">({r.reason})</span> : null}
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
Recreate the previous “Ranking AI” behavior: a client-side form posting to /api/evaluate-with-search, which returns a deterministic ranking (no external dependencies). Added a /api/health endpoint. Tailwind content paths ensured. No new packages required.

## Testing
- Open / → enter Criteria {"clarity":1,"creativity":1} and Candidates A,B,C → click Rank now.
- Expect JSON-backed results list sorted by score.
- GET /api/health → should return { ok: true }.


------
https://chatgpt.com/codex/tasks/task_e_68d536600f888323a2cfaea01a7ec6f8