### PR TITLE
feat: add NextAuth and ranking UI overhaul

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { handlers as GET, handlers as POST } from "@/lib/auth";

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,7 +1,7 @@
-export const runtime = 'edge';
+export const runtime = "edge";
+
 export async function GET() {
   return new Response(JSON.stringify({ ok: true, ts: Date.now() }), {
-    headers: { 'content-type': 'application/json' },
-    status: 200
+    headers: { "content-type": "application/json" },
   });
 }

--- a/app/api/rank/route.ts
+++ b/app/api/rank/route.ts
@@ -1,0 +1,111 @@
+export const runtime = "nodejs";
+
+type Criteria = Record<string, number>;
+type Result = { item: string; score: number; reason?: string };
+
+function parseCandidates(raw: unknown): string[] {
+  const arr = Array.isArray(raw) ? raw : String(raw ?? "").split(/[,，\n]/);
+  const cleaned = arr.map((s) => s.trim()).filter(Boolean);
+  return Array.from(new Set(cleaned)).slice(0, 200);
+}
+function parseCriteria(raw: unknown): Criteria {
+  if (!raw) return {};
+  try {
+    return typeof raw === "string" ? JSON.parse(raw) : (raw as Criteria);
+  } catch {
+    return {};
+  }
+}
+function heuristicScore(item: string, criteria: Criteria): number {
+  const weight = Object.values(criteria).reduce((acc, value) => acc + Number(value || 0), 0) || 1;
+  const base = [...item].reduce((acc, ch) => acc + ch.charCodeAt(0), 0) % 101;
+  return Math.round(base * weight);
+}
+
+function mergeResults(results: Result[], candidates: string[], criteria: Criteria): Result[] {
+  const missing = candidates.filter((candidate) => !results.find((r) => r.item === candidate));
+  const filled = [
+    ...results,
+    ...missing.map((item) => ({ item, score: heuristicScore(item, criteria), reason: "fallback" })),
+  ];
+  return filled;
+}
+
+async function rankWithOpenAI(criteria: Criteria, candidates: string[]): Promise<Result[]> {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error("NO_OPENAI_KEY");
+
+  const sys = `You are a ranking engine. Return JSON only:
+{"results":[{"item":"<candidate>","score":<0..100>,"reason":"<short>"}...]}
+- Use weights in "criteria" to score candidates 0..100.
+- Higher is better. One-line reason per item.`;
+
+  const user = JSON.stringify({ criteria, candidates });
+
+  const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      temperature: 0.2,
+      messages: [
+        { role: "system", content: sys },
+        { role: "user", content: user },
+      ],
+    }),
+  });
+  if (!resp.ok) throw new Error(`OPENAI_${resp.status}`);
+  const data = await resp.json();
+  const text = data.choices?.[0]?.message?.content ?? "";
+  const json = (() => {
+    try {
+      return JSON.parse(text);
+    } catch {
+      const match = text.match(/\{[\s\S]*\}/);
+      if (!match) throw 0;
+      return JSON.parse(match[0]);
+    }
+  })();
+  const listed = (json.results ?? []).map((r: any) => ({
+    item: String(r.item),
+    score: Math.max(0, Math.min(100, Number(r.score) || 0)),
+    reason: r.reason ? String(r.reason) : undefined,
+  }));
+  return mergeResults(listed, candidates, criteria).sort((a, b) => b.score - a.score);
+}
+
+export async function POST(req: Request) {
+  try {
+    const ct = req.headers.get("content-type") || "";
+    let criteria: Criteria = {}, candidates: string[] = [];
+    if (ct.includes("application/json")) {
+      const body = await req.json();
+      criteria = parseCriteria(body.criteria);
+      candidates = parseCandidates(body.candidates);
+    } else {
+      const fd = await req.formData();
+      criteria = parseCriteria(fd.get("criteria")?.toString());
+      candidates = parseCandidates(fd.get("candidates")?.toString());
+    }
+    if (!candidates.length) {
+      return Response.json({ ok: false, message: "Candidates required" }, { status: 400 });
+    }
+
+    let results: Result[];
+    try {
+      results = await rankWithOpenAI(criteria, candidates);
+    } catch {
+      results = candidates
+        .map((item) => ({ item, score: heuristicScore(item, criteria), reason: "heuristic" }))
+        .sort((a, b) => b.score - a.score);
+    }
+
+    return Response.json({ ok: true, criteria, results }, { status: 200 });
+  } catch (e: any) {
+    return Response.json({ ok: false, error: e?.message ?? "unknown" }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  return Response.json({ ok: true, ts: Date.now() });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,20 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .card { @apply bg-white rounded-2xl shadow-sm ring-1 ring-black/5; }
+  .card-body { @apply p-6 md:p-8; }
+  .btn { @apply inline-flex items-center justify-center rounded-lg px-4 py-2 font-medium; }
+  .btn-primary { @apply btn bg-black text-white hover:bg-black/90 disabled:opacity-50; }
+  .input { @apply block w-full rounded-lg border-gray-300 focus:border-black focus:ring-black; }
+  .textarea { @apply input min-h-[160px]; }
+  .label { @apply block text-sm font-medium text-gray-700 mb-1; }
+  .pill { @apply inline-flex items-center gap-2 rounded-full bg-gray-100 px-3 py-1 text-sm; }
+  .pill-x { @apply cursor-pointer text-gray-500 hover:text-gray-800; }
+  .kbd { @apply rounded border bg-gray-50 px-1.5 py-0.5 text-xs font-mono; }
+  .table { @apply w-full text-sm; }
+  .th { @apply text-left font-semibold px-3 py-2 bg-gray-50; }
+  .td { @apply px-3 py-2 border-t; }
+  .notice-err { @apply rounded-lg bg-red-50 text-red-800 ring-1 ring-red-200 px-3 py-2; }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,14 @@
+"use client";
+import type { ReactNode } from "react";
+import { SessionProvider } from "next-auth/react";
 import "./globals.css";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body>
+        <SessionProvider>{children}</SessionProvider>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,90 +1,235 @@
 "use client";
-import { useState } from "react";
+import { useState, useMemo } from "react";
+import { useSession } from "next-auth/react";
+import AuthButton from "@/components/AuthButton";
 
 type Result = { item: string; score: number; reason?: string };
 
-export default function Home() {
-  const [criteria, setCriteria] = useState('{\n  "clarity": 1,\n  "creativity": 1\n}');
-  const [candidates, setCandidates] = useState('A,B,C');
-  const [results, setResults] = useState<Result[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+const PRESETS = [
+  { name: "文章評価", criteria: { clarity: 2, creativity: 1, accuracy: 2 }, candidates: ["案A", "案B", "案C"] },
+  {
+    name: "商品比較",
+    criteria: { price: 2, quality: 3, popularity: 1 },
+    candidates: ["A社", "B社", "C社", "D社"],
+  },
+  { name: "採用選考", criteria: { skill: 3, culture: 2, potential: 2 }, candidates: ["山田", "佐藤", "田中"] },
+];
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setLoading(true);
-    setError(null);
-    setResults([]);
+export default function Home() {
+  const { data: session } = useSession();
+  const [criteriaText, setCriteriaText] = useState(
+    JSON.stringify(PRESETS[0].criteria, null, 2),
+  );
+  const [candidateInput, setCandidateInput] = useState("");
+  const [cands, setCands] = useState<string[]>(PRESETS[0].candidates);
+  const [results, setResults] = useState<Result[]>([]);
+  const [sortBy, setSortBy] = useState<"rank" | "score" | "name">("rank");
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const criteriaObj = useMemo(() => {
     try {
-      // API に JSON で投げる（フォームPOSTより確実）
-      const res = await fetch("/api/evaluate-with-search", {
+      return JSON.parse(criteriaText || "{}");
+    } catch {
+      return null;
+    }
+  }, [criteriaText]);
+
+  function addFromInput(force?: boolean) {
+    const parts = candidateInput.split(/[,，]/).map((s) => s.trim()).filter(Boolean);
+    if (!parts.length && !force) return;
+    setCands(Array.from(new Set([...cands, ...parts])));
+    setCandidateInput("");
+  }
+  function removeCand(x: string) {
+    setCands(cands.filter((c) => c !== x));
+  }
+  function applyPreset(p: (typeof PRESETS)[number]) {
+    setCriteriaText(JSON.stringify(p.criteria, null, 2));
+    setCands(p.candidates);
+    setResults([]);
+    setErr(null);
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    setResults([]);
+    if (!session) {
+      setErr("ログインが必要です（右上の Sign in）。");
+      return;
+    }
+    if (!criteriaObj) {
+      setErr("Criteria JSON が不正です。");
+      return;
+    }
+    if (!cands.length) {
+      setErr("候補を1件以上追加してください。");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch("/api/rank", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          criteria: JSON.parse(criteria || "{}"),
-          candidates: candidates.split(",").map(s => s.trim()).filter(Boolean),
-        }),
+        body: JSON.stringify({ criteria: criteriaObj, candidates: cands }),
       });
       const data = await res.json();
       if (!res.ok || !data.ok) throw new Error(data?.error || data?.message || `HTTP ${res.status}`);
       setResults(data.results as Result[]);
-    } catch (err: any) {
-      setError(err?.message ?? "Request failed");
+    } catch (e: any) {
+      setErr(e?.message || "リクエストに失敗しました");
     } finally {
       setLoading(false);
     }
   }
 
+  const sorted = useMemo(() => {
+    const arr = [...results];
+    if (sortBy === "score") arr.sort((a, b) => b.score - a.score);
+    if (sortBy === "name") arr.sort((a, b) => a.item.localeCompare(b.item));
+    return arr;
+  }, [results, sortBy]);
+
+  const total = results.reduce((a, r) => a + r.score, 0);
+
   return (
-    <main className="p-8 max-w-3xl mx-auto space-y-6">
-      <h1 className="text-3xl font-bold">Ranking AI</h1>
-      <p className="text-gray-600">JSON の評価基準と候補リストからランキングを生成します。</p>
-
-      <form onSubmit={handleSubmit} className="space-y-3">
-        <label className="block">
-          <span className="font-medium">Criteria (JSON)</span>
-          <textarea
-            value={criteria}
-            onChange={(e) => setCriteria(e.target.value)}
-            rows={8}
-            className="w-full border p-2 rounded"
-          />
-        </label>
-        <label className="block">
-          <span className="font-medium">Candidates (comma-separated)</span>
-          <input
-            value={candidates}
-            onChange={(e) => setCandidates(e.target.value)}
-            className="w-full border p-2 rounded"
-          />
-        </label>
-        <button
-          type="submit"
-          disabled={loading}
-          className="px-4 py-2 rounded bg-black text-white disabled:opacity-50"
-        >
-          {loading ? "Ranking..." : "Rank now"}
-        </button>
-      </form>
-
-      {error && (
-        <div className="text-red-600">Error: {error}</div>
-      )}
-
-      {results.length > 0 && (
-        <div className="space-y-2">
-          <h2 className="text-xl font-semibold mt-6">Results</h2>
-          <ol className="list-decimal pl-6">
-            {results.map((r, i) => (
-              <li key={r.item} className="leading-7">
-                <span className="font-semibold">{i + 1}. {r.item}</span>
-                <span className="ml-2 text-sm text-gray-500">score: {r.score}</span>
-                {r.reason ? <span className="ml-2 text-sm text-gray-400">({r.reason})</span> : null}
-              </li>
-            ))}
-          </ol>
+    <main className="mx-auto max-w-5xl p-6 md:p-10 space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-4xl font-bold tracking-tight">Ranking AI</h1>
+          <p className="text-gray-600">Google ログイン後に、OpenAI を使って候補を格付けします。</p>
         </div>
-      )}
+        <AuthButton />
+      </div>
+
+      <section className="card">
+        <div className="card-body space-y-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm text-gray-500">Presets:</span>
+            {PRESETS.map((p) => (
+              <button
+                key={p.name}
+                type="button"
+                onClick={() => applyPreset(p)}
+                className="pill hover:bg-gray-200"
+              >
+                {p.name}
+              </button>
+            ))}
+            <span className="ml-auto text-xs text-gray-500">
+              候補追加: <span className="kbd">Enter</span> / <span className="kbd">,</span>
+            </span>
+          </div>
+
+          <form className="grid grid-cols-1 gap-6 md:grid-cols-2" onSubmit={onSubmit}>
+            <div>
+              <label className="label">Criteria (JSON)</label>
+              <textarea
+                value={criteriaText}
+                onChange={(e) => setCriteriaText(e.target.value)}
+                className="textarea font-mono"
+                placeholder='{"clarity":1,"creativity":1}'
+              />
+              {!criteriaObj && <div className="mt-2 notice-err">JSON を復元できませんでした。</div>}
+            </div>
+
+            <div className="space-y-2">
+              <label className="label">Candidates</label>
+              <input
+                className="input"
+                placeholder="候補を入力して Enter または ,"
+                value={candidateInput}
+                onChange={(e) => setCandidateInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === ",") {
+                    e.preventDefault();
+                    addFromInput(true);
+                  }
+                }}
+              />
+              <div className="flex flex-wrap gap-2">
+                {cands.map((c) => (
+                  <span className="pill" key={c}>
+                    {c}
+                    <button
+                      type="button"
+                      className="pill-x"
+                      onClick={() => removeCand(c)}
+                      aria-label={`${c}を削除`}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="md:col-span-2 flex items-center gap-3">
+              <button
+                className="btn-primary"
+                type="submit"
+                disabled={loading || !criteriaObj || !cands.length}
+              >
+                {loading ? "Ranking..." : "Rank now"}
+              </button>
+              {err && <div className="notice-err">{err}</div>}
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section className="card">
+        <div className="card-body space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Results</h2>
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-gray-500">Sort:</span>
+              <select
+                className="input h-9"
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as "rank" | "score" | "name")}
+              >
+                <option value="rank">Rank</option>
+                <option value="score">Score</option>
+                <option value="name">Name</option>
+              </select>
+            </div>
+          </div>
+
+          {results.length === 0 ? (
+            <p className="text-gray-500 text-sm">まだ結果はありません。上で実行してください。</p>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th className="th">#</th>
+                      <th className="th">Candidate</th>
+                      <th className="th">Score</th>
+                      <th className="th">Reason</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sorted.map((r, i) => (
+                      <tr key={r.item}>
+                        <td className="td">{i + 1}</td>
+                        <td className="td font-medium">{r.item}</td>
+                        <td className="td">{r.score}</td>
+                        <td className="td text-gray-600">{r.reason ?? "-"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="text-sm text-gray-600">
+                {results.length} items ・ Total score: {total}
+              </div>
+            </>
+          )}
+        </div>
+      </section>
     </main>
   );
 }

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { signIn, signOut } from "next-auth/react";
+import { useSession } from "next-auth/react";
+
+export default function AuthButton() {
+  const { data: session, status } = useSession();
+  if (status === "loading") return <button className="btn">...</button>;
+  if (!session) {
+    return (
+      <button className="btn-primary" onClick={() => signIn("google")}>
+        Sign in with Google
+      </button>
+    );
+  }
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-gray-600">Hi, {session.user?.name ?? "user"}</span>
+      <button className="btn" onClick={() => signOut()}>Sign out</button>
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,33 @@
+import NextAuth, { type NextAuthConfig } from "next-auth";
+import Google from "next-auth/providers/google";
+
+/**
+ * JWT strategy なので DB 不要。`NEXTAUTH_SECRET` は必須。
+ * Google の Callback URL は: {HOST}/api/auth/callback/google
+ */
+export const authConfig = {
+  providers: [
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+  ],
+  session: { strategy: "jwt" },
+  pages: {}, // デフォルトUI
+  callbacks: {
+    async jwt({ token, account, profile }) {
+      if (account && profile) {
+        token.provider = account.provider;
+        token.name = (profile as any).name ?? token.name;
+        token.email = (profile as any).email ?? token.email;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      (session as any).provider = (token as any).provider;
+      return session;
+    },
+  },
+} satisfies NextAuthConfig;
+
+export const { handlers, signIn, signOut, auth } = NextAuth(authConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "dependencies": {
         "next": "14.2.5",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "@prisma/client": "^5.16.1",
+        "next-auth": "^5.0.0-beta.21"
       },
       "devDependencies": {
         "@types/node": "^20.12.7",
@@ -19,6 +21,7 @@
         "eslint": "8.57.0",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.4",
+        "@tailwindcss/forms": "^0.5.7",
         "prisma": "^5.16.1",
         "tsx": "^4.9.3",
         "typescript": "5.4.5"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "next": "14.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "@prisma/client": "^5.16.1"
+    "@prisma/client": "^5.16.1",
+    "next-auth": "^5.0.0-beta.21"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
@@ -30,6 +31,7 @@
     "eslint": "8.57.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
+    "@tailwindcss/forms": "^0.5.7",
     "prisma": "^5.16.1",
     "tsx": "^4.9.3",
     "typescript": "5.4.5"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,5 +2,5 @@
 module.exports = {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: { extend: {} },
-  plugins: [],
+  plugins: [require('@tailwindcss/forms')],
 };


### PR DESCRIPTION
## Summary
- integrate NextAuth with Google provider and expose the auth route plus a reusable AuthButton
- add an OpenAI-backed ranking API with heuristic fallback and surface the results in a richer UI with presets, tag inputs, and Tailwind helper classes
- wire Tailwind forms utilities, shared component styles, and a lightweight health check endpoint

## Testing
- ⚠️ `npm install` *(fails: npm registry returned 403 Forbidden for next-auth/@prisma packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5709ada1c8323af961af743e972b4