### PR TITLE
chore: relax node engine and broaden path alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ranking_ai_new",
   "version": "0.1.0",
   "engines": {
-    "node": "20.12.2"
+    "node": ">=20 <21"
   },
   "scripts": {
     "dev": "next dev",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": [
-        "app/*"
+        "*"
       ]
     },
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- relax the Node.js engine constraint to allow any Node 20 release
- widen the @/* TypeScript path alias so imports resolve anywhere under the repo root

## Testing
- npm run lint *(fails: ESLint 9.x requires an eslint.config.js file in this repo)*
- npm run typecheck *(fails: npm install could not fetch dependencies due to 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d5db7173a88323abd1c94746990e4d