### PR TITLE
chore(ci): add 'Regen Lockfile' workflow

### DIFF
--- a/.github/workflows/regen-lock.yml
+++ b/.github/workflows/regen-lock.yml
@@ -1,0 +1,33 @@
+name: Regen Lockfile
+on:
+  workflow_dispatch: {}
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Clean & install
+        run: |
+          rm -rf node_modules package-lock.json yarn.lock pnpm-lock.yaml
+          npm config set fetch-retries 5
+          npm config set fetch-retry-maxtimeout 120000
+          npm install --no-audit --no-fund
+          npx prisma generate || true
+
+      - name: Create PR with updated lockfile
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(lock): regenerate package-lock.json on clean runner"
+          title: "chore(lock): regenerate package-lock.json"
+          body: "Regenerated lockfile to fix CI 'Missing from lock file' errors."
+          branch: chore/regen-lock
+          add-paths: |
+            package-lock.json
+            package.json


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow that regenerates package-lock.json on a clean runner
- configure the workflow to commit the refreshed lockfile via an automated PR

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5dd118f98832396df3d941f89ee2c