### PR TITLE
fix: configure Tailwind v4 PostCSS plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "zustand": "^4.4.0"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.0.0",
         "prisma": "^5.22.0",
         "typescript": "^5.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ranking_ai_new",
   "version": "0.1.0",
   "engines": {
-    "node": "20.12.2"
+    "node": ">=20 <21"
   },
   "scripts": {
     "dev": "next dev",
@@ -23,6 +23,7 @@
     "zustand": "^4.4.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
     "prisma": "^5.22.0",
     "typescript": "^5.6.0"
   }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-  },
-};

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+/** Tailwind v4 */
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};


### PR DESCRIPTION
## Summary
- replace the PostCSS configuration to use the Tailwind v4 `@tailwindcss/postcss` plugin
- add the matching dev dependency and relax the Node engine range to align with Vercel

## Testing
- not run (npm install is blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6c79902e48323834a122e1c369bc7