### PR TITLE
fix(build): use Tailwind v4 PostCSS plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
       },
       "devDependencies": {
         "prisma": "^5.22.0",
-        "typescript": "^5.6.0"
+        "typescript": "^5.6.0",
+        "@tailwindcss/postcss": "^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ranking_ai_new",
   "version": "0.1.0",
   "engines": {
-    "node": "20.12.2"
+    "node": ">=20 <21"
   },
   "scripts": {
     "dev": "next dev",
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "prisma": "^5.22.0",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "@tailwindcss/postcss": "^4.0.0"
   }
 }

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+/** Tailwind v4: use @tailwindcss/postcss */
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-  },
-};


### PR DESCRIPTION
## Summary
- replace the legacy Tailwind PostCSS config with a v4-compatible `postcss.config.cjs`
- add the `@tailwindcss/postcss` dev dependency and relax the Node engine range to align with Tailwind v4 requirements

## Testing
- not run (environment lacks npm registry access)


------
https://chatgpt.com/codex/tasks/task_e_68d6d25843548323b4a4e624c4dfc5f7