### PR TITLE
Add TypeScript typings and update tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,12 @@
         "zustand": "^4.4.0"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.0.0",
+        "@types/node": "^20.16.11",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
         "prisma": "^5.22.0",
-        "typescript": "^5.6.0",
-        "@tailwindcss/postcss": "^4.0.0"
+        "typescript": "^5.6.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "zustand": "^4.4.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/node": "^20.16.11",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "prisma": "^5.22.0",
-    "typescript": "^5.6.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "typescript": "^5.6.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,15 +9,33 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"],
+      "@/*": ["*"],
       "@/components/*": ["components/*"],
       "@/lib/*": ["lib/*"],
       "@/app/*": ["app/*"]
     },
-    "jsx": "react-jsx"
+    "jsx": "preserve"
   },
-  "include": ["next-env.d.ts", "app", "components", "lib", "prisma", "*.ts", "*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "app",
+    "components",
+    "lib",
+    "prisma",
+    "*.ts",
+    "*.tsx",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "prisma/seed.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- add the missing TypeScript definition packages (@types/react, @types/react-dom, @types/node)
- bump the TypeScript dev dependency and refresh the minimal package-lock metadata
- expand tsconfig to include Next.js build artifacts and skip prisma/seed.ts

## Testing
- not run (npm install fails in this environment due to 403 when fetching @prisma/client)


------
https://chatgpt.com/codex/tasks/task_e_68d6d4273e648323b41af02ff019b85a