### PR TITLE
fix: prevent rank API build failures without OpenAI credentials

### DIFF
--- a/app/api/rank/route.ts
+++ b/app/api/rank/route.ts
@@ -1,27 +1,56 @@
 import { NextResponse } from "next/server";
-import { rankCandidates } from "@/lib/openai";
+import { getOpenAIClient, rankCandidates } from "@/lib/openai";
 
 type RequestPayload = {
   criteria?: Record<string, number>;
   candidates?: string[];
 };
 
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  const hasKey = !!(process.env.OPENAI_API_KEY && process.env.OPENAI_API_KEY.trim());
+  return NextResponse.json(
+    { ok: true, openai: hasKey ? "configured" : "missing" },
+    { status: 200 }
+  );
+}
+
 export async function POST(request: Request) {
+  const client = getOpenAIClient();
+  if (!client) {
+    return NextResponse.json(
+      { ok: false, error: "OPENAI_API_KEY is not configured" },
+      { status: 503 }
+    );
+  }
+
+  let body: RequestPayload;
   try {
-    const body = (await request.json()) as RequestPayload;
-    const criteria = body.criteria ?? {};
-    const candidates = Array.isArray(body.candidates) ? body.candidates : [];
+    body = (await request.json()) as RequestPayload;
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+  }
 
-    if (!candidates.length) {
-      return NextResponse.json({ ok: false, error: "At least one candidate is required" }, { status: 400 });
-    }
+  const criteria = body.criteria ?? {};
+  const candidates = Array.isArray(body.candidates) ? body.candidates : [];
 
+  if (!candidates.length) {
+    return NextResponse.json(
+      { ok: false, error: "At least one candidate is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
     const results = await rankCandidates(criteria, candidates);
-
     return NextResponse.json({ ok: true, results }, { status: 200 });
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Unexpected error while generating ranking";
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    const status = message.includes("OpenAI request failed") ? 502 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
   }
 }

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -8,14 +8,27 @@ type RankingItem = {
   reason: string;
 };
 
-const client = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+let cachedClient: OpenAI | null | undefined;
+
+export function getOpenAIClient(): OpenAI | null {
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    cachedClient = null;
+    return null;
+  }
+
+  if (!cachedClient) {
+    cachedClient = new OpenAI({ apiKey });
+  }
+
+  return cachedClient;
+}
 
 const DEFAULT_MODEL = process.env.OPENAI_MODEL ?? "gpt-4o-mini";
 
 export async function rankCandidates(criteria: Criteria, candidates: string[]): Promise<RankingItem[]> {
-  if (!process.env.OPENAI_API_KEY) {
+  const client = getOpenAIClient();
+  if (!client) {
     throw new Error("OPENAI_API_KEY is not configured.");
   }
 
@@ -24,45 +37,50 @@ export async function rankCandidates(criteria: Criteria, candidates: string[]): 
     `Candidates: ${candidates.join(", ")}`,
   ].join("\n\n");
 
-  const response = await client.chat.completions.create({
-    model: DEFAULT_MODEL,
-    temperature: 0.2,
-    response_format: { type: "json_object" },
-    messages: [
-      {
-        role: "system",
-        content:
-          "You are an AI ranking assistant. Rank the given candidates based on the provided criteria. Return JSON with a 'rankings' array where each item includes: candidate (string), score (number from 0 to 100), and reason (string).",
-      },
-      {
-        role: "user",
-        content: prompt,
-      },
-    ],
-  });
-
-  const content = response.choices[0]?.message?.content;
-  if (!content) {
-    throw new Error("OpenAI did not return any content.");
-  }
-
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(content);
+    const response = await client.chat.completions.create({
+      model: DEFAULT_MODEL,
+      temperature: 0.2,
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are an AI ranking assistant. Rank the given candidates based on the provided criteria. Return JSON with a 'rankings' array where each item includes: candidate (string), score (number from 0 to 100), and reason (string).",
+        },
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+    });
+
+    const content = response.choices[0]?.message?.content;
+    if (!content) {
+      throw new Error("OpenAI did not return any content.");
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch (error) {
+      throw new Error("Failed to parse OpenAI response as JSON.");
+    }
+
+    if (typeof parsed !== "object" || parsed === null || !Array.isArray((parsed as any).rankings)) {
+      throw new Error("OpenAI response missing 'rankings' array.");
+    }
+
+    return (parsed as any).rankings
+      .map((item: any) => ({
+        candidate: String(item.candidate),
+        score: Number(item.score),
+        reason: item.reason ? String(item.reason) : "",
+      }))
+      .filter((item: RankingItem) => item.candidate.trim().length > 0)
+      .sort((a: RankingItem, b: RankingItem) => b.score - a.score);
   } catch (error) {
-    throw new Error("Failed to parse OpenAI response as JSON.");
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`OpenAI request failed: ${message}`);
   }
-
-  if (typeof parsed !== "object" || parsed === null || !Array.isArray((parsed as any).rankings)) {
-    throw new Error("OpenAI response missing 'rankings' array.");
-  }
-
-  return (parsed as any).rankings
-    .map((item: any) => ({
-      candidate: String(item.candidate),
-      score: Number(item.score),
-      reason: item.reason ? String(item.reason) : "",
-    }))
-    .filter((item: RankingItem) => item.candidate.trim().length > 0)
-    .sort((a: RankingItem, b: RankingItem) => b.score - a.score);
 }


### PR DESCRIPTION
## Summary
- lazily initialize the OpenAI client to avoid crashes when the API key is missing
- ensure the rank API route returns appropriate errors and expose a health-check GET handler
- mark the route as dynamic to keep it out of build-time evaluation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d7897a008323adf65c542d8c1028