### PR TITLE
Fix type dependencies for production builds

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,4 @@
-// /// <reference types="next" />
-// /// <reference types="next/image-types/global" />
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
 // NOTE: This file should not be edited

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
+        "@types/node": "^20",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
         "clsx": "^2.0.0",
         "lucide-react": "^0.344.0",
         "next": "14.2.5",
@@ -16,12 +19,12 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "tailwindcss": "4.0.0",
+        "typescript": "^5.6.3",
         "zustand": "^4.4.0"
       },
       "devDependencies": {
-        "prisma": "^5.22.0",
-        "typescript": "^5.6.0",
-        "@tailwindcss/postcss": "^4.0.0"
+        "@tailwindcss/postcss": "^4.0.0",
+        "prisma": "^5.22.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
     "clsx": "^2.0.0",
     "lucide-react": "^0.344.0",
     "next": "14.2.5",
@@ -20,11 +23,11 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tailwindcss": "4.0.0",
+    "typescript": "^5.6.3",
     "zustand": "^4.4.0"
   },
   "devDependencies": {
-    "prisma": "^5.22.0",
-    "typescript": "^5.6.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@tailwindcss/postcss": "^4.0.0",
+    "prisma": "^5.22.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM"],
+    "lib": [
+      "ES2020",
+      "DOM"
+    ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
@@ -11,13 +14,39 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"],
-      "@/components/*": ["components/*"],
-      "@/lib/*": ["lib/*"],
-      "@/app/*": ["app/*"]
+      "@/*": [
+        "./*"
+      ],
+      "@/components/*": [
+        "components/*"
+      ],
+      "@/lib/*": [
+        "lib/*"
+      ],
+      "@/app/*": [
+        "app/*"
+      ]
     },
-    "jsx": "react-jsx"
+    "jsx": "preserve",
+    "noEmit": true,
+    "incremental": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
   },
-  "include": ["next-env.d.ts", "app", "components", "lib", "prisma", "*.ts", "*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "app",
+    "components",
+    "lib",
+    "prisma",
+    "*.ts",
+    "*.tsx",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "prisma/seed.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- move TypeScript type packages into dependencies so production installs keep them
- normalize `next-env.d.ts` and expand TypeScript config for reliable Next.js type resolution
- update lockfile entries to reflect the dependency changes

## Testing
- `npm install --no-audit --no-fund` *(fails: npm error code E403 Forbidden when fetching @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68d76059b9188323ae09be1ab83f2765