### PR TITLE
fix(api): lazily create OpenAI client and harden rank route

### DIFF
--- a/app/api/rank/route.ts
+++ b/app/api/rank/route.ts
@@ -1,27 +1,81 @@
-import { NextResponse } from "next/server";
-import { rankCandidates } from "@/lib/openai";
+import { getOpenAI, rankCandidatesWithClient } from "@/lib/openai";
 
-type RequestPayload = {
-  criteria?: Record<string, number>;
-  candidates?: string[];
-};
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
-export async function POST(request: Request) {
+type RankRequest = { criteria?: Record<string, number>; candidates?: string[] };
+
+type JsonBody = Record<string, unknown>;
+
+type CriteriaInput = Record<string, unknown>;
+
+type NormalisedCriteria = Record<string, number>;
+
+function json(body: JsonBody, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+function normaliseCriteria(value: CriteriaInput): NormalisedCriteria | null {
+  const entries = Object.entries(value)
+    .map(([key, raw]) => [key, Number(raw)] as const)
+    .filter(([, weight]) => Number.isFinite(weight));
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return Object.fromEntries(entries);
+}
+
+export async function GET() {
+  const hasKey = !!process.env.OPENAI_API_KEY?.trim();
+  return json({ ok: true, openai: hasKey ? "configured" : "missing" });
+}
+
+export async function POST(req: Request) {
+  let payload: RankRequest;
   try {
-    const body = (await request.json()) as RequestPayload;
-    const criteria = body.criteria ?? {};
-    const candidates = Array.isArray(body.candidates) ? body.candidates : [];
+    payload = await req.json();
+  } catch {
+    return json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+  }
 
-    if (!candidates.length) {
-      return NextResponse.json({ ok: false, error: "At least one candidate is required" }, { status: 400 });
-    }
+  const criteria = payload.criteria;
+  const candidates = payload.candidates;
 
-    const results = await rankCandidates(criteria, candidates);
+  if (!criteria || typeof criteria !== "object" || Array.isArray(criteria)) {
+    return json({ ok: false, error: "criteria must be an object of weights" }, { status: 400 });
+  }
 
-    return NextResponse.json({ ok: true, results }, { status: 200 });
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    return json({ ok: false, error: "At least one candidate is required" }, { status: 400 });
+  }
+
+  const normalisedCriteria = normaliseCriteria(criteria as CriteriaInput);
+  if (!normalisedCriteria) {
+    return json({ ok: false, error: "criteria must contain at least one numeric weight" }, { status: 400 });
+  }
+
+  const client = getOpenAI();
+  if (!client) {
+    return json({ ok: false, error: "OPENAI_API_KEY is not set" }, { status: 503 });
+  }
+
+  try {
+    const results = await rankCandidatesWithClient(client, normalisedCriteria, candidates);
+    return json({ ok: true, results });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Unexpected error while generating ranking";
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    const message = error instanceof Error ? error.message : "OpenAI request failed";
+    return json(
+      { ok: false, error: "OpenAI request failed", detail: message },
+      { status: 502 },
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add a lazily-instantiated OpenAI helper that normalises and validates ranking results
- require dynamic runtime for `/api/rank`, normalise criteria input, and return consistent JSON responses with detailed errors

## Testing
- npm run build *(fails: `next` binary unavailable before installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d767e7af708323bace4ee2053945a4