### PR TITLE
Add type dependencies and prebuild type guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
+        "@types/node": "^20.14.10",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
         "clsx": "^2.0.0",
         "lucide-react": "^0.344.0",
         "next": "14.2.5",
@@ -16,11 +19,11 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "tailwindcss": "4.0.0",
+        "typescript": "^5.6.0",
         "zustand": "^4.4.0"
       },
       "devDependencies": {
         "prisma": "^5.22.0",
-        "typescript": "^5.6.0",
         "@tailwindcss/postcss": "^4.0.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,16 @@
   },
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/check-types.mjs",
     "build": "next build",
     "start": "next start",
     "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "clsx": "^2.0.0",
     "lucide-react": "^0.344.0",
     "next": "14.2.5",
@@ -20,11 +24,11 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tailwindcss": "4.0.0",
+    "typescript": "^5.6.0",
     "zustand": "^4.4.0"
   },
   "devDependencies": {
     "prisma": "^5.22.0",
-    "typescript": "^5.6.0",
     "@tailwindcss/postcss": "^4.0.0"
   }
 }

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync('npx', ['tsc', '--noEmit'], {
+  stdio: 'inherit',
+  shell: false,
+});
+
+if (result.error) {
+  console.error('\nFailed to launch TypeScript compiler.', result.error);
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  console.error('\nType checking failed. Aborting build.');
+  process.exit(result.status ?? 1);
+}
+
+console.log('Type checking succeeded.');


### PR DESCRIPTION
## Summary
- add the React and Node type packages and TypeScript to the runtime dependencies required by Vercel builds
- add a prebuild script that runs a TypeScript type check to fail builds early on type issues

## Testing
- npm install *(fails: registry access returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d4398c108323ae6f0e59ce008d75