### PR TITLE
fix: lazily initialize OpenAI client for rank API

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -8,14 +8,20 @@ type RankingItem = {
   reason: string;
 };
 
-const client = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+const DEFAULT_MODEL = process.env.OPENAI_MODEL?.trim() || "gpt-4o-mini";
 
-const DEFAULT_MODEL = process.env.OPENAI_MODEL ?? "gpt-4o-mini";
+export function getOpenAI(): OpenAI | null {
+  const key = process.env.OPENAI_API_KEY?.trim();
+  if (!key) return null;
+  return new OpenAI({ apiKey: key });
+}
 
-export async function rankCandidates(criteria: Criteria, candidates: string[]): Promise<RankingItem[]> {
-  if (!process.env.OPENAI_API_KEY) {
+export async function rankCandidates(
+  criteria: Criteria,
+  candidates: string[],
+  client: OpenAI | null = getOpenAI(),
+): Promise<RankingItem[]> {
+  if (!client) {
     throw new Error("OPENAI_API_KEY is not configured.");
   }
 


### PR DESCRIPTION
## Summary
- lazily initialize the OpenAI SDK so builds no longer require a key at module load
- update the rank API route to expose a lightweight GET status and return 503 when the key is missing

## Testing
- `npm run build` *(fails: next binary not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ede54268832386096702b9c6cae5