### PR TITLE
Add workflow to regenerate npm lockfile

### DIFF
--- a/.github/workflows/regen-lock.yml
+++ b/.github/workflows/regen-lock.yml
@@ -1,33 +1,24 @@
-name: Regen Lockfile
+name: Regen lockfile
 on:
   workflow_dispatch: {}
+
 jobs:
   regen:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-          cache: npm
-
-      - name: Clean & install
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Clean & install to regenerate lock
         run: |
-          rm -rf node_modules package-lock.json yarn.lock pnpm-lock.yaml
-          npm config set fetch-retries 5
-          npm config set fetch-retry-maxtimeout 120000
+          rm -rf node_modules package-lock.json pnpm-lock.yaml yarn.lock
           npm install --no-audit --no-fund
-          npx prisma generate || true
-
-      - name: Create PR with updated lockfile
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "chore(lock): regenerate package-lock.json on clean runner"
-          title: "chore(lock): regenerate package-lock.json"
-          body: "Regenerated lockfile to fix CI 'Missing from lock file' errors."
-          branch: chore/regen-lock
-          add-paths: |
-            package-lock.json
-            package.json
+      - name: Commit lockfile
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          git commit -m "chore: regenerate package-lock with @types/react in dependencies" || echo "no changes"
+          git push


### PR DESCRIPTION
## Summary
- add a manually triggered GitHub Actions workflow to regenerate the npm lockfile with the latest dependency layout
- ensure the workflow cleans existing lockfiles before reinstalling and commits the refreshed package-lock.json back to the branch

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68d80e6b10a883239a87a63e06703175