### PR TITLE
fix: unpin tailwind dependencies for Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "@tailwindcss/postcss": "^9.0.0",
+    "@tailwindcss/postcss": "latest",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -23,7 +23,7 @@
     "openai": "^4.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "tailwindcss": "4.0.0",
+    "tailwindcss": "latest",
     "typescript": "^5.6.3",
     "zustand": "^4.4.0"
   },


### PR DESCRIPTION
## Summary
- update `@tailwindcss/postcss` and `tailwindcss` dependency versions to `latest` so Vercel resolves published releases

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d81619c5608323ab5b39a63937ab72