### PR TITLE
Fix Tailwind setup and guard sign-out UI

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,11 @@
 import Link from 'next/link';
 
+import { SignOutButton } from '@/components/SignOutButton';
+
+const hasGoogleAuth = Boolean(
+  process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET,
+);
+
 export default function Home() {
   return (
     <main>
@@ -17,16 +23,11 @@ export default function Home() {
             <div className="flex items-center justify-center gap-3">
               <Link
                 href="/dashboard"
-                className="inline-flex items-center rounded-xl bg-indigo-600 px-5 py-3 text-white font-medium shadow hover:bg-indigo-700 transition"
+                className="inline-flex items-center rounded-xl bg-indigo-600 px-5 py-3 text-white font-medium shadow transition hover:bg-indigo-700"
               >
                 ダッシュボードへ移動
               </Link>
-              <Link
-                href="/api/auth/signout"
-                className="inline-flex items-center rounded-xl border border-gray-300 px-5 py-3 text-gray-700 font-medium hover:bg-gray-50 transition"
-              >
-                サインアウト
-              </Link>
+              {hasGoogleAuth ? <SignOutButton /> : null}
             </div>
           </div>
         </div>

--- a/components/SignOutButton.tsx
+++ b/components/SignOutButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { signOut } from "next-auth/react";
+import { cn } from "@/lib/utils";
+
+type SignOutButtonProps = {
+  className?: string;
+  children?: ReactNode;
+};
+
+export function SignOutButton({ className, children }: SignOutButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => signOut({ callbackUrl: "/" })}
+      className={cn(
+        "inline-flex items-center rounded-xl border border-gray-300 px-5 py-3 text-gray-700 font-medium transition hover:bg-gray-50",
+        className,
+      )}
+    >
+      {children ?? "サインアウト"}
+    </button>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "@tailwindcss/postcss": "^9.0.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -23,7 +22,9 @@
     "openai": "^4.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "tailwindcss": "4.0.0",
+    "autoprefixer": "10.4.20",
+    "postcss": "8.4.47",
+    "tailwindcss": "3.4.13",
     "typescript": "^5.6.3",
     "zustand": "^4.4.0"
   },

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,0 @@
-/** Tailwind v4: use @tailwindcss/postcss */
-module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,2 +1,0 @@
-import tailwind from '@tailwindcss/postcss';
-export default { plugins: { tailwind } };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  content: ["./app/**/*.{js,ts,jsx,tsx,mdx}", "./components/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: { extend: {} },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- revert the Tailwind toolchain to the stable v3 stack and restore the standard PostCSS configuration
- add a reusable client-side sign-out button that calls `next-auth` via POST and gate it behind Google OAuth envs on the home page

## Testing
- npm install *(fails: 403 Forbidden fetching @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68d81be2cdf88323aee465564c8059d7