### PR TITLE
fix: pin Tailwind to v3 stack and restore v3 PostCSS config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "@tailwindcss/postcss": "^9.0.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -23,7 +22,9 @@
     "openai": "^4.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "tailwindcss": "4.0.0",
+    "autoprefixer": "10.4.19",
+    "postcss": "8.4.47",
+    "tailwindcss": "3.4.13",
     "typescript": "^5.6.3",
     "zustand": "^4.4.0"
   },

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,0 @@
-/** Tailwind v4: use @tailwindcss/postcss */
-module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,2 +1,0 @@
-import tailwind from '@tailwindcss/postcss';
-export default { plugins: { tailwind } };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
   theme: { extend: {} },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- remove the Tailwind v4/PostCSS 9 dependency path and pin Tailwind, PostCSS, and Autoprefixer to the stable v3-compatible versions
- replace the Tailwind v4-specific PostCSS configs with the standard Tailwind v3 configuration file
- expand the Tailwind content globs to cover JS/TS/JSX/TSX/MDX files in app and components

## Testing
- npm install *(fails in this environment: 403 Forbidden when fetching @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68d833b085d8832398847d2fcf031155